### PR TITLE
The base of gradient paints that match up with SWF data.

### DIFF
--- a/include/VG/openvg.h
+++ b/include/VG/openvg.h
@@ -341,6 +341,9 @@ typedef enum {
 
   /* Pattern paint parameters */
   VG_PAINT_PATTERN_TILING_MODE                = 0x1A06,
+  
+  /* 2x3 gradient paint parameters */
+  VG_PAINT_2x3_GRADIENT                    = 0x1A08,
 
   VG_PAINT_PARAM_TYPE_FORCE_SIZE              = VG_MAX_ENUM
 } VGPaintParamType;
@@ -350,6 +353,10 @@ typedef enum {
   VG_PAINT_TYPE_LINEAR_GRADIENT               = 0x1B01,
   VG_PAINT_TYPE_RADIAL_GRADIENT               = 0x1B02,
   VG_PAINT_TYPE_PATTERN                       = 0x1B03,
+
+  /* 2x3 matrix gradients */
+  VG_PAINT_TYPE_LINEAR_2x3_GRADIENT               = 0x1B04,
+  VG_PAINT_TYPE_RADIAL_2x3_GRADIENT               = 0x1B05,
 
   VG_PAINT_TYPE_FORCE_SIZE                    = VG_MAX_ENUM
 } VGPaintType;

--- a/src/mkPaint.cpp
+++ b/src/mkPaint.cpp
@@ -92,6 +92,11 @@ namespace MonkVG {	// Internal Implementation
 					_colorRampStops.push_back( stop );
 				}
 				break;
+			case VG_PAINT_2x3_GRADIENT:
+				for ( int i = 0; i < 6; i++ ) {
+					_paint2x3Gradient[i] = fv[i];
+				}
+				break;
 			
 			default:
 				IContext::instance().setError( VG_ILLEGAL_ARGUMENT_ERROR );

--- a/src/mkPaint.h
+++ b/src/mkPaint.h
@@ -58,6 +58,7 @@ namespace MonkVG {
 		VGboolean				_colorRampPremultiplied;
 		VGfloat					_paintLinearGradient[4];
 		VGfloat					_paintRadialGradient[5];
+		VGfloat					_paint2x3Gradient[6];
 		VGTilingMode			_patternTilingMode;
 		//	Image*					m_pattern;
 		struct Stop_t {

--- a/src/opengl/glPaint.cpp
+++ b/src/opengl/glPaint.cpp
@@ -332,11 +332,377 @@ namespace MonkVG {
 		free(image);
 		
 	}
+    
+    void OpenGLPaint::buildLinear2x3GradientImage( VGfloat pathWidth, VGfloat pathHeight ) {
+		// generated image sizes
+		const int width = 64, height = 64;
+		unsigned int* image = (unsigned int*)malloc( width * height * sizeof(unsigned int) );
+		//	VG_COLOR_RAMP_SPREAD_PAD                    = 0x1C00,
+		//	VG_COLOR_RAMP_SPREAD_REPEAT                 = 0x1C01,
+		//	VG_COLOR_RAMP_SPREAD_REFLECT                = 0x1C02,
+		
+		VGColorRampSpreadMode spreadMode = _colorRampSpreadMode;
+		
+		const int stopCnt = _colorRampStops.size();
+		
+		//	from OpenVG specification PDF
+		//
+		//			dx(x - x0) + dy((y - y0)
+		// g(x,y) = ------------------------
+		//				dx^2 + dy^2
+		// where dx = x1 - x0, dy = y1 - y0
+		//
+        
+        /*
+         Setup x & y values baed on gradient size:
+            x|y = (scale * 32768 * 0.05)
+         Two transformations:
+            1. Flash transform, based on matrix:
+                x' = x + y * r1 + tx
+                y' = y + x * r0 + ty
+            2. Conversion to OpenVG space:
+                x'' = (x' / pathWidth) * width
+                y'' = (y' / pathHeight) * height
+         */
+        
+        // initialize gradient space
+        float gradientSize = 32768 * 0.05;
+		VGfloat p1[2] = { gradientSize/2, gradientSize/2};
+		VGfloat p0[2] = { -p1[0], p1[1]};
+        
+        // flash trasformation based on matrix values
+        VGfloat p0p[2] = {
+            _paint2x3Gradient[0] * p0[0]  + p0[1] * _paint2x3Gradient[5],
+            _paint2x3Gradient[1] * p0[1]  + p0[0] * _paint2x3Gradient[4]};
+        VGfloat p1p[2] = {
+            _paint2x3Gradient[0] * p1[0]  + p1[1] * _paint2x3Gradient[5],
+            _paint2x3Gradient[1] * p1[1]  + p1[0] * _paint2x3Gradient[4]};
+        
+        // convert to the shapes space
+        p0[0] = (p0p[0] + pathWidth/2) / pathWidth * width;
+        p0[1] = (p0p[1] + pathHeight/2) / pathHeight * height;
+        p1[0] = (p1p[0] + pathWidth/2) / pathWidth * width;
+        p1[1] = (p1p[1] + pathHeight/2) / pathHeight * height;
+        
+        //float gradientWidth = _paint2x3Gradient[0] * 32768 * 0.05; // scale gradients
+        //float delta = (pathWidth-gradientWidth) / pathWidth;
+		//VGfloat p0[2] = { (delta/2) * width, 0};
+		//VGfloat p1[2] = { p0[0] + ((gradientWidth / pathWidth) * width), 0};
+		
+		
+		float dx = p1[0] - p0[0];
+		float dy = p1[1] - p0[1];
+		float denominator = (dx * dx) + (dy * dy);
+		// todo: assert denominator != 0
+		
+		for ( int x = 0; x < width; x++ ) {
+			for ( int y = 0; y < height; y++ ) {
+				float numerator = dx * (x - p0[0]) + dy * (y - p0[1]);
+				float g = numerator / denominator;
+				
+				
+				
+				// color = c0 + (c1 - c0)(g - x0)/(x1 - x0)
+				// where c0 = stop color 0, c1 = stop color 1
+				// where x0 = stop offset 0, x1 = stop offset 1
+				float finalcolor[4];
+				float* stop0 = 0;
+				float* stop1 = 0;
+				
+				
+				if ( spreadMode == VG_COLOR_RAMP_SPREAD_PAD ) {
+					if ( g < 0 ) {
+						stop0 = _colorRampStops[0].a;
+						for ( int i = 0; i < 4; i++ ) {
+							finalcolor[i] = stop0[i+1];
+						}
+						
+					} else if ( g < _colorRampStops[0].a[0]) { // if the first color is after 0 fill with the first color
+                        stop0 = _colorRampStops[0].a;
+						for ( int i = 0; i < 4; i++ ) {
+							finalcolor[i] = stop0[i+1];
+						}
+                    } else if( g > 1 ) {
+						stop0 = _colorRampStops[stopCnt -1].a;
+						for ( int i = 0; i < 4; i++ ) {
+							finalcolor[i] = stop0[i+1];
+						}
+						
+					} else if ( g > _colorRampStops[stopCnt - 1].a[0]) { // if the last color is before 1.0 fill with the last color
+                        stop0 = _colorRampStops[stopCnt -1].a;
+						for ( int i = 0; i < 4; i++ ) {
+							finalcolor[i] = stop0[i+1];
+						}
+                    } else {
+						// determine which stops
+						for ( int i = 0; i < stopCnt; i++ ) {
+							if ( g >= _colorRampStops[i].a[0] && g <= _colorRampStops[i+1].a[0] ) {
+								stop0 = _colorRampStops[i].a;
+								stop1 = _colorRampStops[i+1].a;
+								//printf( "stopds: %d --> %d\n", i, i+1);
+								break;
+							}
+						}
+						
+						for ( int i = 0; i < 4; i++ ) {
+							finalcolor[i] = stop0[i+1] + (stop1[i+1] - stop0[i+1])*(g - stop0[0])/(stop1[0] - stop0[0]);
+						}
+						
+					}
+				} else {
+					int w = int(fabsf(g));
+					
+					if ( spreadMode == VG_COLOR_RAMP_SPREAD_REPEAT ) {
+						if ( g < 0 ) {
+							g = 1 - (fabs(g) - w);
+						} else {
+							g = g - w;
+						}
+					} else if( spreadMode == VG_COLOR_RAMP_SPREAD_REFLECT ) {
+						if ( g < 0 ) {
+							if ( w % 2 == 0 ) { // even
+								g = (fabsf(g) - w);
+							} else {	// odd
+								g = (1 - (fabsf(g) - w));
+							}
+							
+						} else {
+							if ( w % 2 == 0 ) { // even
+								g = g - w;
+							} else {	// odd
+								g = 1 - (g - w);
+							}
+						}
+						
+					}
+					
+					// clamp
+					if ( g > 1 ) {
+						g = 1;
+					}
+					if ( g < 0 ) {
+						g = 0;
+					}
+					
+					// determine which stops
+					for ( int i = 0; i < stopCnt; i++ ) {
+						if ( g >= _colorRampStops[i].a[0] && g <= _colorRampStops[i+1].a[0] ) {
+							stop0 = _colorRampStops[i].a;
+							stop1 = _colorRampStops[i+1].a;
+							//printf( "stopds: %d --> %d\n", i, i+1);
+							break;
+						}
+					}
+					
+					assert( stop0 && stop1 );
+					for ( int i = 0; i < 4; i++ ) {
+						finalcolor[i] = stop0[i+1] + (stop1[i+1] - stop0[i+1])*(g - stop0[0])/(stop1[0] - stop0[0]);
+					}
+				}
+				
+				unsigned int color 
+				= (uint32_t(finalcolor[3] * 255) << 24) 
+				| (uint32_t(finalcolor[2] * 255) << 16)
+				| (uint32_t(finalcolor[1] * 255) << 8)
+				| (uint32_t(finalcolor[0] * 255) << 0);
+				
+				image[(y*width) + x] = color;
+			}
+		}
+		
+		// create openvg image
+		_gradientImage = vgCreateImage(VG_sRGBA_8888, width, height, 0 );
+		
+		vgImageSubData( _gradientImage, image, -1, VG_sRGBA_8888, 0, 0, width, height );
+		
+		free(image);
+        
+	}
+	
+    void OpenGLPaint::buildRadial2x3GradientImage( VGfloat pathWidth, VGfloat pathHeight ) {
+		// generated image sizes
+		const int width = 64, height = 64;
+		unsigned int* image = (unsigned int*)malloc( width * height * sizeof(unsigned int) );
+		//	VG_COLOR_RAMP_SPREAD_PAD                    = 0x1C00,
+		//	VG_COLOR_RAMP_SPREAD_REPEAT                 = 0x1C01,
+		//	VG_COLOR_RAMP_SPREAD_REFLECT                = 0x1C02,
+		
+		VGColorRampSpreadMode spreadMode = _colorRampSpreadMode;
+		
+		const int stopCnt = _colorRampStops.size();
+		
+		//	from OpenVG specification PDF
+		//
+		// VG_PAINT_RADIAL_GRADIENT. { cx, cy, fx, fy, r }.
+		//
+		//					(dx * fx' + dy * fy') + sqrt( r^2 * (dx^2 + dy^2) - (dx * fy' - dy fx') ^ 2 )
+		//		g(x,y)	=	-----------------------------------------------------------------------------
+		//												r^2 - (fx'^2 + fy'^2)
+		// where:
+		//		fx' = fx - cx, fy' = fy - cy
+		//		dx = x - fx, dy = y - fy
+		//		
+		
+		/*
+         
+         float fxn = (( _paintRadialGradient[2])/pathWidth) * width;
+         float fyn = ((_paintRadialGradient[3])/pathHeight) * height;
+         float fxp = fxn - (((_paintRadialGradient[0])/pathWidth) * width);
+         float fyp = fyn - (((_paintRadialGradient[1])/pathHeight) * height);
+         
+         // ??? normalizing radius on the path width but it could be either or???
+         float rn = (_paintRadialGradient[4]/pathWidth) * width;
+         
+         */
+		// normalize the focal point
+		float fxn = width/2;
+		float fyn = height / 2;
+		float fxp = fxn - (width/2);
+		float fyp = fyn - (height/2);
+		
+		// ??? normalizing radius on the path width but it could be either or???
+		float rn = width / 2;
+		
+		float denominator = (rn*rn) - (fxp*fxp + fyp*fyp);
+        
+		
+		for ( int x = 0; x < width; x++ ) {
+			float dx = x - fxn;
+			for ( int y = 0; y < height; y++ ) {
+				float dy = y - fyn;
+				
+				float numerator = (dx * fxp + dy * fyp);
+				float df = dx * fyp - dy * fxp;
+				numerator += sqrtf( (rn*rn) * (dx*dx + dy*dy) - (df*df)  );
+				float g = numerator / denominator;
+				
+				
+				
+				// color = c0 + (c1 - c0)(g - x0)/(x1 - x0)
+				// where c0 = stop color 0, c1 = stop color 1
+				// where x0 = stop offset 0, x1 = stop offset 1
+				float finalcolor[4];
+				float* stop0 = 0;
+				float* stop1 = 0;
+				
+				
+				if ( spreadMode == VG_COLOR_RAMP_SPREAD_PAD ) {
+					if ( g < 0 ) {
+						stop0 = _colorRampStops[0].a;
+						for ( int i = 0; i < 4; i++ ) {
+							finalcolor[i] = stop0[i+1];
+						}
+						
+					} else if ( g < _colorRampStops[0].a[0]) { // if the first color is after 0 fill with the first color
+                        stop0 = _colorRampStops[0].a;
+						for ( int i = 0; i < 4; i++ ) {
+							finalcolor[i] = stop0[i+1];
+						}
+                    } else if( g > 1 ) {
+						stop0 = _colorRampStops[stopCnt -1].a;
+						for ( int i = 0; i < 4; i++ ) {
+							finalcolor[i] = stop0[i+1];
+						}
+					} else if ( g > _colorRampStops[stopCnt - 1].a[0]) { // if the last color is before 1.0 fill with the last color
+                        stop0 = _colorRampStops[stopCnt -1].a;
+						for ( int i = 0; i < 4; i++ ) {
+							finalcolor[i] = stop0[i+1];
+						}
+                    } else {
+						// determine which stops
+						for ( int i = 0; i < stopCnt; i++ ) {
+							if ( g >= _colorRampStops[i].a[0] && g <= _colorRampStops[i+1].a[0] ) {
+								stop0 = _colorRampStops[i].a;
+								stop1 = _colorRampStops[i+1].a;
+								//printf( "stopds: %d --> %d\n", i, i+1);
+								break;
+							}
+						}
+						
+						for ( int i = 0; i < 4; i++ ) {
+							finalcolor[i] = stop0[i+1] + (stop1[i+1] - stop0[i+1])*(g - stop0[0])/(stop1[0] - stop0[0]);
+						}
+						
+					}
+				} else {
+					int w = int(fabsf(g));
+					
+					if ( spreadMode == VG_COLOR_RAMP_SPREAD_REPEAT ) {
+						if ( g < 0 ) {
+							g = 1 - (fabs(g) - w);
+						} else {
+							g = g - w;
+						}
+					} else if( spreadMode == VG_COLOR_RAMP_SPREAD_REFLECT ) {
+						if ( g < 0 ) {
+							if ( w % 2 == 0 ) { // even
+								g = (fabsf(g) - w);
+							} else {	// odd
+								g = (1 - (fabsf(g) - w));
+							}
+							
+						} else {
+							if ( w % 2 == 0 ) { // even
+								g = g - w;
+							} else {	// odd
+								g = 1 - (g - w);
+							}
+						}
+						
+					}
+					
+					// clamp
+					if ( g > 1 ) {
+						g = 1;
+					}
+					if ( g < 0 ) {
+						g = 0;
+					}
+					
+					// determine which stops
+					for ( int i = 0; i < stopCnt; i++ ) {
+						if ( g >= _colorRampStops[i].a[0] && g <= _colorRampStops[i+1].a[0] ) {
+							stop0 = _colorRampStops[i].a;
+							stop1 = _colorRampStops[i+1].a;
+							//printf( "stopds: %d --> %d\n", i, i+1);
+							break;
+						}
+					}
+					
+					assert( stop0 && stop1 );
+					for ( int i = 0; i < 4; i++ ) {
+						finalcolor[i] = stop0[i+1] + (stop1[i+1] - stop0[i+1])*(g - stop0[0])/(stop1[0] - stop0[0]);
+					}
+				}
+				
+				unsigned int color 
+				= (uint32_t(finalcolor[3] * 255) << 24) 
+				| (uint32_t(finalcolor[2] * 255) << 16)
+				| (uint32_t(finalcolor[1] * 255) << 8)
+				| (uint32_t(finalcolor[0] * 255) << 0);
+				
+				image[(y*width) + x] = color;
+			}
+		}
+		
+		// create openvg image
+		_gradientImage = vgCreateImage(VG_sRGBA_8888, width, height, 0 );
+		
+		vgImageSubData( _gradientImage, image, -1, VG_sRGBA_8888, 0, 0, width, height );
+		
+		free(image);
+		
+	}
+    
 	void OpenGLPaint::buildGradientImage( VGfloat pathWidth, VGfloat pathHeight ) {
 		if ( getPaintType() == VG_PAINT_TYPE_LINEAR_GRADIENT ) {
 			buildLinearGradientImage( pathWidth, pathHeight );
 		} else if ( getPaintType() == VG_PAINT_TYPE_RADIAL_GRADIENT ) {
 			buildRadialGradientImage( pathWidth, pathHeight );
+		} else if ( getPaintType() == VG_PAINT_TYPE_LINEAR_2x3_GRADIENT ) {
+			buildLinear2x3GradientImage( pathWidth, pathHeight );
+		}  else if ( getPaintType() == VG_PAINT_TYPE_RADIAL_2x3_GRADIENT ) {
+			buildRadial2x3GradientImage( pathWidth, pathHeight );
 		}
 	}
 

--- a/src/opengl/glPaint.h
+++ b/src/opengl/glPaint.h
@@ -24,6 +24,8 @@ namespace MonkVG {
 		void setGLState();
 		void buildLinearGradientImage( VGfloat pathWidth, VGfloat pathHeight );
 		void buildRadialGradientImage( VGfloat pathWidth, VGfloat pathHeight );
+		void buildLinear2x3GradientImage( VGfloat pathWidth, VGfloat pathHeight );
+		void buildRadial2x3GradientImage( VGfloat pathWidth, VGfloat pathHeight );
 		void buildGradientImage( VGfloat pathWidth, VGfloat pathHeight );
 		virtual bool isDirty() { return _isDirty; }
 		virtual void setIsDirty( bool b ) { _isDirty = b; }

--- a/src/opengl/glPath.cpp
+++ b/src/opengl/glPath.cpp
@@ -91,7 +91,7 @@ namespace MonkVG {
 		if ( _fillPaintForPath && _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_COLOR ) {
 			glDisable(GL_TEXTURE_2D);
 			glDisableClientState( GL_TEXTURE_COORD_ARRAY );
-		} else if ( _fillPaintForPath && (_fillPaintForPath->getPaintType() == VG_PAINT_TYPE_LINEAR_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_RADIAL_GRADIENT) ) {
+		} else if ( _fillPaintForPath && (_fillPaintForPath->getPaintType() == VG_PAINT_TYPE_LINEAR_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_RADIAL_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_RADIAL_2x3_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_LINEAR_2x3_GRADIENT) ) {
 			glEnable( GL_TEXTURE_2D );
 			glEnableClientState( GL_TEXTURE_COORD_ARRAY );
 			
@@ -106,7 +106,7 @@ namespace MonkVG {
 			glBindBuffer( GL_ARRAY_BUFFER, _fillVBO );
 			if ( _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_COLOR ) {
 				glVertexPointer( 2, GL_FLOAT, sizeof(v2_t), 0 );
-			} else if ( (_fillPaintForPath->getPaintType() == VG_PAINT_TYPE_LINEAR_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_RADIAL_GRADIENT) ) {
+			} else if ( (_fillPaintForPath->getPaintType() == VG_PAINT_TYPE_LINEAR_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_RADIAL_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_RADIAL_2x3_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_LINEAR_2x3_GRADIENT) ) {
 				_fillPaintForPath->getGradientImage()->bind();
 				glVertexPointer( 2, GL_FLOAT, sizeof(textured_vertex_t), (GLvoid*)offsetof(textured_vertex_t, v) );
 				glTexCoordPointer( 2, GL_FLOAT, sizeof(textured_vertex_t), (GLvoid*)offsetof(textured_vertex_t, uv) );
@@ -114,7 +114,7 @@ namespace MonkVG {
 			glDrawArrays( GL_TRIANGLES, 0, _numberFillVertices );
 			
 			// unbind any textures being used
-			if ( (_fillPaintForPath->getPaintType() == VG_PAINT_TYPE_LINEAR_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_RADIAL_GRADIENT) ) {
+			if ( (_fillPaintForPath->getPaintType() == VG_PAINT_TYPE_LINEAR_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_RADIAL_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_RADIAL_2x3_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_LINEAR_2x3_GRADIENT) ) {
 				_fillPaintForPath->getGradientImage()->unbind();
 				glContext.setImageMode( oldImageMode );
 				
@@ -836,7 +836,7 @@ namespace MonkVG {
 			glBindBuffer( GL_ARRAY_BUFFER, _fillVBO );
 			if ( _fillPaintForPath && _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_COLOR ) {
 				glBufferData( GL_ARRAY_BUFFER, _vertices.size() * sizeof(float), &_vertices[0], GL_STATIC_DRAW );
-			} else if ( _fillPaintForPath && (_fillPaintForPath->getPaintType() == VG_PAINT_TYPE_LINEAR_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_RADIAL_GRADIENT) ) {
+			} else if ( _fillPaintForPath && (_fillPaintForPath->getPaintType() == VG_PAINT_TYPE_LINEAR_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_RADIAL_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_RADIAL_2x3_GRADIENT || _fillPaintForPath->getPaintType() == VG_PAINT_TYPE_LINEAR_2x3_GRADIENT) ) {
 				vector<textured_vertex_t> texturedVertices;
 				for ( vector<float>::const_iterator it = _vertices.begin(); it != _vertices.end(); it++ ) {
 					// build up the textured vertex


### PR DESCRIPTION
SWF gradient configs don't have information about the height and width of the surface they are painting so I pass in the 2x3 matrix that configures the gradient and then apply it creating the gl paint.

Not totally in love with this approach. I'd be willing to stick this in a branch until I redesign it. The alternative approach is to delay config of the pain until the shape the gradient is being applied to is known. Probably won't be able to get to it for a week or so due to other projects.
