### PR TITLE
Drop autoconf requirment to 2.88 which is default on ubuntu 12.04

### DIFF
--- a/projects/MonkVG-autotools/configure.ac
+++ b/projects/MonkVG-autotools/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.69])
+AC_PREREQ([2.68])
 AC_INIT([MonkVG], [1.1],[] )
 AC_CONFIG_SRCDIR([../../glu/libtess/dict.c])
 


### PR DESCRIPTION
Lets more people build it, works fine under 12.04 with the correct libs.
