### PR TITLE
Fix vgSetPaint()

### DIFF
--- a/src/mkPaint.cpp
+++ b/src/mkPaint.cpp
@@ -122,7 +122,11 @@ VG_API_CALL void vgDestroyPaint(VGPaint paint) {
 }
 
 VG_API_CALL void vgSetPaint(VGPaint paint, VGbitfield paintModes) {
-	if ( paint == VG_INVALID_HANDLE ) {
+	if ( paint != VG_INVALID_HANDLE && ((IPaint*)paint)->getType() != BaseObject::kPaintType ) {
+		IContext::instance().setError( VG_BAD_HANDLE_ERROR );
+		return;
+	}
+	if ( !paintModes || paintModes & ~(VG_FILL_PATH | VG_STROKE_PATH) ) {
 		IContext::instance().setError( VG_BAD_HANDLE_ERROR );
 		return;
 	}

--- a/src/opengl/glContext.cpp
+++ b/src/opengl/glContext.cpp
@@ -264,7 +264,8 @@ namespace MonkVG {
 			IContext::setStrokePaint( paint );
 			OpenGLPaint* glPaint = (OpenGLPaint*)_stroke_paint;
 			//glPaint->setGLState();
-			glPaint->setIsDirty( true );
+                        if (glPaint)
+                            glPaint->setIsDirty( true );
 		}
 	}
 	
@@ -273,7 +274,8 @@ namespace MonkVG {
 			IContext::setFillPaint( paint );
 			OpenGLPaint* glPaint = (OpenGLPaint*)_fill_paint;
 			//glPaint->setGLState();
-			glPaint->setIsDirty( true );
+                        if (glPaint)
+                            glPaint->setIsDirty( true );
 		}
 		
 	}


### PR DESCRIPTION
The standard explicitly allows VG_INVALID_HANDLE argument to vgSetPaint().
